### PR TITLE
Updated shortcodes class to make it global

### DIFF
--- a/includes/class-wp-job-manager-shortcodes.php
+++ b/includes/class-wp-job-manager-shortcodes.php
@@ -509,4 +509,4 @@ class WP_Job_Manager_Shortcodes {
 	}
 }
 
-new WP_Job_Manager_Shortcodes();
+$GLOBALS['job_manager_shortcodes'] = new WP_Job_Manager_Shortcodes();


### PR DESCRIPTION
The only change is the very last line in the file:
Line 512:
Original: `new WP_Job_Manager_Shortcodes();`
Recommended: `$GLOBALS['job_manager_shortcodes'] = new WP_Job_Manager_Shortcodes();`

Making the class globally available allows users to modify the actions in their theme's functions.php file. 

As a case in point, my WP Job Manager implementation considers Job Type as the top-level filter so I want this to show up first, at the start of the filters. With this class being global, I can remove the action on line 18 and replace it with 'job_manager_job_filters_start' to achieve my desired order of operations. 

Example in my functions.php file:

```
function pjobs_shortcode_tweaks() {
    global $job_manager_shortcodes;
    remove_action( 'job_manager_job_filters_end', array( $job_manager_shortcodes, 'job_filter_job_types' ), 20 );
    add_action( 'job_manager_job_filters_start', array( $job_manager_shortcodes, 'job_filter_job_types'), 20 );
}
add_action('init', 'pjobs_shortcode_tweaks');
```
